### PR TITLE
Fix geo URI

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 						</dt>
 						<dd>
 							בניין מיטשל (הבניין החדש), מכללת שנקר - בי״ס גבוה להנדסה ולעיצוב, רמת גן (<a href="http://www.shenkar.ac.il/template/default.aspx?maincat=5&amp;catid=32" class="external text" title="http://www.shenkar.ac.il/template/default.aspx?maincat=5&amp;catid=32">הוראות הגעה</a>)
-							<a href="geo:32.0897,34.802373?q=32.0897,34.802373(אוגוסט פינגווין 2015)" class="mobile" title="קישור זה עשוי שלא לפעול בדפדפנים שולחניים – ניתן לגשת אליו ממכשירים ניידים">קבלת הוראות הכוונה לנייד</a>
+							<a href="geo:32.0897,34.802373?q=32.0897,34.802373" class="mobile" title="קישור זה עשוי שלא לפעול בדפדפנים שולחניים – ניתן לגשת אליו ממכשירים ניידים">קבלת הוראות הכוונה לנייד</a>
 						</dd>
 					</dl>
 				</div>


### PR DESCRIPTION
While the Geo URI works great on Google Maps, Waze seems to work differently, and tries to parse the LABEL instead of the latitude/longitude. While it is possible to workaround this by tapping the back button, removing the label should make it work as expected.
