### PR TITLE
Changed the gold sponsor img size to work on both mobile and desktop

### DIFF
--- a/ap2016.css
+++ b/ap2016.css
@@ -224,7 +224,8 @@ h1, h2 {
 }
 
 .gold img{
-  height: 200px;
+    width: 80vw;
+    max-width: 600px;
 }
 
 .silver img{


### PR DESCRIPTION
Size was set by height in pixels, which can yield problematic behavior.
Chose instead a combination:
- width specified as percentage (80%) of viewport width, for small screens
- max-width specified in pixels (600px) to prevent image growing too much
