### PR TITLE
Fix Share->share

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -114,7 +114,7 @@
       <h2>Social Media</h2>
       <div>
         <p>You are welcome to share this page and invite your friends. <a href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fap.hamakor.org.il%2F">Share on Facebook</a>,
-          <a href="https://twitter.com/intent/tweet?text=+%D7%92%D7%9D+%D7%90%D7%A0%D7%99+%D7%90%D7%A9%D7%AA%D7%AA%D7%A3+%D7%91%D7%9B%D7%A0%D7%A1+%D7%90%D7%95%D7%92%D7%95%D7%A1%D7%98+%D7%A4%D7%99%D7%A0%D7%92%D7%95%D7%95%D7%99%D7%9F+2017.+%D7%90%D7%AA%D7%9D+%D7%9E%D7%95%D7%96%D7%9E%D7%A0%D7%99%D7%9D+%D7%9C%D7%94%D7%A6%D7%98%D7%A8%D7%A3+%D7%90%D7%9C%D7%99%D7%A0%D7%95!++%23%D7%90%D7%A42017&url=http%3A%2F%2Fap.hamakor.org.il%2F&via=hamakor">Share on Twitter</a>.
+          <a href="https://twitter.com/intent/tweet?text=+%D7%92%D7%9D+%D7%90%D7%A0%D7%99+%D7%90%D7%A9%D7%AA%D7%AA%D7%A3+%D7%91%D7%9B%D7%A0%D7%A1+%D7%90%D7%95%D7%92%D7%95%D7%A1%D7%98+%D7%A4%D7%99%D7%A0%D7%92%D7%95%D7%95%D7%99%D7%9F+2017.+%D7%90%D7%AA%D7%9D+%D7%9E%D7%95%D7%96%D7%9E%D7%A0%D7%99%D7%9D+%D7%9C%D7%94%D7%A6%D7%98%D7%A8%D7%A3+%D7%90%D7%9C%D7%99%D7%A0%D7%95!++%23%D7%90%D7%A42017&url=http%3A%2F%2Fap.hamakor.org.il%2F&via=hamakor">share on Twitter</a>.
         <p>You are welcome to tag your pictures and statuses during the convention with <strong>#ap2017</strong>.</p>
 
         <p><a href="https://www.facebook.com/hashtag/%D7%90%D7%A42017">Publish a message on Facebook and watch previous messages.</a></p>


### PR DESCRIPTION
Since "Share on twitter" is not  a new sentence (it comes after a
comma (,), not a period (.)), it should start with a lower-case
letter, not a capital one.

This patch was accepted on the ap2016 branch, but unfortunately it
was merged only after the ap2017 branch was branched out of it.