### PR TITLE
Standardize capitalization of DevOps

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -169,7 +169,7 @@
           <div class="track col-12 col-sm-3 col-centered">
             <a href="tracks.html#devops_track">
               <img src="../images/devops-israel-300x150-transparent.png" alt="devops logo"/>
-              <h3>Devops in Israel</h3>
+              <h3>DevOps in Israel</h3>
             </a>
           </div>
           <div class="track col-12 col-sm-3 col-centered">

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
           <div class="track col-12 col-sm-3 col-centered-rtl">
             <a href="tracks.html#devops_track">
               <img src="images/devops-israel-300x150-transparent.png" alt="devops logo"/>
-              <h3>Devops in Israel</h3>
+              <h3>DevOps in Israel</h3>
             </a>
           </div>
           <div class="track col-12 col-sm-3 col-centered-rtl">


### PR DESCRIPTION
The standard spelling seems to be DevOps, with a capital O, even on
this site.

This patch standardizes the spelling throughout this site.