### PR TITLE
auto deploy on push to ap2023 branch

### DIFF
--- a/.github/workflows/deploy-on-push.yml
+++ b/.github/workflows/deploy-on-push.yml
@@ -1,0 +1,19 @@
+name: deploy-on-push
+run-name: ${{ github.actor }} is deploying to hamakor server
+on:
+  push:
+    branches:
+      - ap2023
+jobs:
+  deploy-branch-to-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+        with:
+          server: 'srv6.hamakor.org.il'
+          username: ${{ secrets.AP_SFTP_USERNAME }}
+          password: ${{ secrets.AP_SFTP_PASSWORD }}
+          sftp_only: true
+          local_path: './*'
+          remote_path: '/www/2023'


### PR DESCRIPTION
Create a github workflow that auto-deploys to the live server (srv6) on any push to ap2023 branch
(this relies on the fact that ap2023 branch is protected, and mandates review before merging)

Note that I already added the repository-secrets for  SFTP access to the server (the password and username are specific to the august- penguin app, and is managed via the apps management UI on srv6).
