### PR TITLE
avoid deployment action being run in fork repos

### DIFF
--- a/.github/workflows/deploy-on-push.yml
+++ b/.github/workflows/deploy-on-push.yml
@@ -6,6 +6,7 @@ on:
       - ap2023
 jobs:
   deploy-branch-to-server:
+    if: github.repository == 'Hamakor/AugustPenguin'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Deployment script is currently being run on people's personal forks.
It fails, of course (because the fork projects do not have the credential secrets), but that is a waste of resources, and a bit annoying for the contributor (because they get warnings, until they go and manually turn off  actions in their config).

This adds an if condition, which will ensure that deployment will only be run if we are in the main project.
