### PR TITLE
CFS on english page

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -75,8 +75,11 @@
       <div id="center-msg">
         The annual convention of the Israeli Free and Open Source Software community
       </div>
+    <div>
       <div>
-      Want to sponsor? Please contact <a href="mailto:board@hamakor.org.il">board@hamakor.org.il</a>
+        <h2>Want to sponsor?</h2>
+          see <a href="https://drive.google.com/file/d/1eNeu7VPHDMUOcwObAYJ98dTz8odFUCjO/view?usp=sharing">sponsorship offer</a><br/>
+          contact: <a href="mailto:board@hamakor.org.il">board@hamakor.org.il</a>
       </div>
       <a name="location" id="location"></a>
       <h2>Where and When?</h2>

--- a/index.html
+++ b/index.html
@@ -163,15 +163,15 @@
       <p><a href="http://ap.hamakor.org.il/2013/">אוגוסט פינגווין 2013</a></p>
       <p><a href="http://ap.hamakor.org.il/2012/">אוגוסט פינגווין 2012</a></p>
       <p><a href="http://ap.hamakor.org.il/2011/">אוגוסט פינגווין 2011</a></p>
-      <p><a href="http://ap.hamakor.org.il/2010/">אוגוסט פינגווין 2010</a></p>
-      <p><a href="http://ap.hamakor.org.il/2009/">אוגוסט פינגווין 2009</a></p>
-      <p><a href="http://ap.hamakor.org.il/2008/">אוגוסט פינגווין 2008</a></p>
-      <p><a href="http://ap.hamakor.org.il/2007/">אוגוסט פינגווין 2007</a></p>
-      <p><a href="http://ap.hamakor.org.il/2006/">אוגוסט פינגווין 5</a></p>
-      <p><a href="http://ap.hamakor.org.il/2005/">אוגוסט פינגווין 4</a></p>
-      <p><a href="http://ap.hamakor.org.il/2004/">אוגוסט פינגווין 3</a></p>
-      <p><a href="http://ap.hamakor.org.il/2003/">אוגוסט פינגווין 2</a></p>
-      <p><a href="http://ap.hamakor.org.il/2002/">אוגוסט פינגווין 1</a></p>
+      <p><!--a href="http://ap.hamakor.org.il/2010/"-->אוגוסט פינגווין 2010</a></p>
+      <p><!--a href="http://ap.hamakor.org.il/2009/"-->אוגוסט פינגווין 2009</a></p>
+      <p><!--a href="http://ap.hamakor.org.il/2008/"-->אוגוסט פינגווין 2008</a></p>
+      <p><!--a href="http://ap.hamakor.org.il/2007/"-->אוגוסט פינגווין 2007</a></p>
+      <p><!--a href="http://ap.hamakor.org.il/2006/"-->אוגוסט פינגווין 5</a></p>
+      <p><!--a href="http://ap.hamakor.org.il/2005/"-->אוגוסט פינגווין 4</a></p>
+      <p><!--a href="http://ap.hamakor.org.il/2004/"-->אוגוסט פינגווין 3</a></p>
+      <p><!--a href="http://ap.hamakor.org.il/2003/"-->אוגוסט פינגווין 2</a></p>
+      <p><!--a href="http://ap.hamakor.org.il/2002/"-->אוגוסט פינגווין 1</a></p>
     </div>
 
     <div id="greetings">נשמח לראותכם!</div>

--- a/index.html
+++ b/index.html
@@ -83,17 +83,16 @@
     <div id="center-msg">
       הכנס המרכזי של קהילת התוכנה החופשית והקוד הפתוח בישראל
     </div>
-    
-      
+
     <div>
       <h2>רוצים לתת חסות?</h2>
         <a href="https://drive.google.com/file/d/1eNeu7VPHDMUOcwObAYJ98dTz8odFUCjO/view?usp=sharing">למידע נוסף</a><br/>
         ליצירת קשר: <a href="mailto:board@hamakor.org.il">board@hamakor.org.il</a>
     </div>
+
     <a name="location" id="location"></a>
     <h2>איפה ומתי?</h2>
     <dl class="location">
-      
       <dt>
         מועד הכנס:
       </dt>


### PR DESCRIPTION
* Adds the CFS link to the English page as well
* minor: align some whitespace in the hebrew page
* Disable broken links to older Penguins (temporary until the sites are restored)
